### PR TITLE
fix(unplugins): add dynamic imports for optional peer dependencies to avoid errors

### DIFF
--- a/packages/unplugins/src/rehype/shiki/index.ts
+++ b/packages/unplugins/src/rehype/shiki/index.ts
@@ -1,5 +1,5 @@
-import { rehypeHighlight, type HighlightOptions } from '@sveltek/markdown'
-import { createHighlighter, type BuiltinTheme } from 'shiki'
+import type { HighlightOptions } from '@sveltek/markdown'
+import type { BuiltinTheme } from 'shiki'
 import type { Root } from 'hast'
 import type { Plugin } from '@/types'
 import type { ShikiOptions } from './types'
@@ -38,14 +38,16 @@ export const rehypeShiki: Plugin<[ShikiOptions?], Root> = function (
   const defaultTheme = theme || 'github-dark-default'
   const defaultLangs = langs || ['javascript', 'typescript', 'svelte']
 
-  const shikiHighlighter = createHighlighter({
-    ...highlighter,
-    themes: highlighter?.themes ||
-      (themes && (Object.values(themes) as BuiltinTheme[])) || [defaultTheme],
-    langs: highlighter?.langs || defaultLangs,
-  })
-
   return async (tree, file) => {
+    const { rehypeHighlight } = await import('@sveltek/markdown')
+    const { createHighlighter } = await import('shiki')
+
+    const shikiHighlighter = createHighlighter({
+      ...highlighter,
+      themes: highlighter?.themes ||
+        (themes && (Object.values(themes) as BuiltinTheme[])) || [defaultTheme],
+      langs: highlighter?.langs || defaultLangs,
+    })
     const { codeToHtml } = await shikiHighlighter
 
     const highlightOptions: HighlightOptions = {


### PR DESCRIPTION
## Type of Change

- [x] Bug fix

## Request Description

Adds dynamic imports for optional peer dependencies `@sveltek/markdown` and `shiki` to avoid possible errors during dev (missed that since I tested this with pre-installed peer dependencies).
