### PR TITLE
feat(markdown): add new root option to rehype-highlight plugin

### DIFF
--- a/packages/markdown/src/compile/types/highlight.ts
+++ b/packages/markdown/src/compile/types/highlight.ts
@@ -1,4 +1,4 @@
-import type { Highlighter } from '@/plugins/types'
+import type { Highlighter, HighlightOptions } from '@/plugins/types'
 
 export interface Highlight {
   /**
@@ -19,4 +19,24 @@ export interface Highlight {
    * @default undefined
    */
   highlighter?: Highlighter
+  /**
+   * Specifies custom options for the `root` node (usually the `<pre>` tag).
+   *
+   * @example
+   *
+   * ```ts
+   * svelteMarkdown({
+   *   highlight: {
+   *     root: (node) => {
+   *       node.tagName = 'div'
+   *       node.properties.id = 'code-highlight'
+   *       // ...
+   *     }
+   *   }
+   * })
+   * ```
+   *
+   * @default undefined
+   */
+  root?: HighlightOptions['root']
 }

--- a/packages/markdown/src/plugins/rehype/highlight/index.ts
+++ b/packages/markdown/src/plugins/rehype/highlight/index.ts
@@ -24,7 +24,7 @@ export const rehypeHighlight: Plugin<[HighlightOptions], Root> = (
   options: HighlightOptions,
 ) => {
   return async (tree) => {
-    const { highlighter } = options
+    const { highlighter, root } = options
 
     if (!highlighter) return
 
@@ -34,6 +34,7 @@ export const rehypeHighlight: Plugin<[HighlightOptions], Root> = (
       if (node.tagName !== 'pre' || !node.children?.length) return
       const [code] = node.children
       if (code.type === 'element' && code.tagName === 'code') els.push(code)
+      root?.(node)
     })
 
     const highlight = async (el: Element) => {

--- a/packages/markdown/src/plugins/rehype/highlight/types.ts
+++ b/packages/markdown/src/plugins/rehype/highlight/types.ts
@@ -1,3 +1,5 @@
+import type { Element } from 'hast'
+
 export interface HighlighterData {
   lang: string | undefined
   meta: string | undefined
@@ -15,4 +17,10 @@ export interface HighlightOptions {
    * @default undefined
    */
   highlighter?: Highlighter
+  /**
+   * Specifies custom options for the `root` node (usually the `<pre>` tag).
+   *
+   * @default undefined
+   */
+  root?: (node: Element) => void
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated. -->

## Type of Change

- [x] New feature

## Request Description

Adds new `root` option to `rehypeHighlight` internal plugin.

### highlight.root

Specifies custom options for the `root` node (usually the `<pre>` tag).

```ts
svelteMarkdown({
  highlight: {
    root: (node) => {
      node.tagName = 'div'
      node.properties.id = 'code-highlight'
      // ...
    },
  },
})
```