### PR TITLE
feat(unplugins): add new root option to rehype-shiki plugin

### DIFF
--- a/packages/unplugins/src/rehype/shiki/index.ts
+++ b/packages/unplugins/src/rehype/shiki/index.ts
@@ -33,16 +33,25 @@ import type { ShikiOptions } from './types'
 export const rehypeShiki: Plugin<[ShikiOptions?], Root> = function (
   options: ShikiOptions = {},
 ) {
-  const { theme, themes, langs, highlighter, codeToHtml: codeHtml } = options
+  const {
+    theme,
+    themes,
+    langs,
+    highlighter,
+    codeToHtml: codeHtml,
+    root = (node) => {
+      node.tagName = 'div'
+    },
+  } = options
 
   const defaultTheme = theme || 'github-dark-default'
   const defaultLangs = langs || ['javascript', 'typescript', 'svelte']
 
   return async (tree, file) => {
     const { rehypeHighlight } = await import('@sveltek/markdown')
-    const { createHighlighter } = await import('shiki')
+    const { getSingletonHighlighter } = await import('shiki')
 
-    const shikiHighlighter = createHighlighter({
+    const shikiHighlighter = getSingletonHighlighter({
       ...highlighter,
       themes: highlighter?.themes ||
         (themes && (Object.values(themes) as BuiltinTheme[])) || [defaultTheme],
@@ -64,6 +73,7 @@ export const rehypeShiki: Plugin<[ShikiOptions?], Root> = function (
           })
         }
       },
+      root,
     }
 
     const transformer = rehypeHighlight.call(this, highlightOptions)

--- a/packages/unplugins/src/rehype/shiki/types.ts
+++ b/packages/unplugins/src/rehype/shiki/types.ts
@@ -4,6 +4,7 @@ import {
   type CodeOptionsSingleTheme,
   type CodeOptionsMultipleThemes,
 } from 'shiki'
+import type { HighlightOptions } from '@sveltek/markdown'
 
 type HighlighterOptions = Parameters<typeof createHighlighter>[0]
 
@@ -75,4 +76,22 @@ export interface ShikiOptions {
    * @default undefined
    */
   parseMeta?: (meta: string | undefined) => void
+  /**
+   * Specifies custom options for the `root` node (usually the `<pre>` tag).
+   *
+   * @example
+   *
+   * ```ts
+   * {
+   *   root: (node) => {
+   *     node.tagName = 'div'
+   *     node.properties.id = 'code-highlight'
+   *     // ...
+   *   }
+   * }
+   * ```
+   *
+   * @default undefined
+   */
+  root?: HighlightOptions['root']
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated. -->

## Type of Change

- [x] New feature

## Request Description

### root

Specifies custom options for the `root` node (usually the `<pre>` tag).

```ts
{
  root: (node) => {
    node.tagName = 'div'
    node.properties.id = 'code-highlight'
    // ...
  }
}
```