### PR TITLE
feat(markdown): add new experimental options to compile fn

### DIFF
--- a/packages/markdown/src/compile/index.ts
+++ b/packages/markdown/src/compile/index.ts
@@ -24,7 +24,12 @@ import type { FileData, CompileOptions } from './types'
 
 export async function compile(
   source: string,
-  { filename, config = {} }: CompileOptions,
+  {
+    filename,
+    config = {},
+    htmlTag = true,
+    module: optionsModule = true,
+  }: CompileOptions,
 ): Promise<Processed> {
   const {
     preprocessors = [],
@@ -87,7 +92,7 @@ export async function compile(
     .use(usePlugins(data.plugins?.rehype))
     .use(usePlugins(layout?.plugins?.rehype))
     .use(usePlugins(entry?.plugins?.rehype))
-    .use(rehypeRenderCode)
+    .use(rehypeRenderCode, { htmlTag })
     .use(rehypeCreateLayout)
     .use(rehypeCreateComponents)
     .use(rehypeStringify, { allowDangerousHtml: true })
@@ -129,7 +134,7 @@ export async function compile(
     s.prepend(svelteInstance.content)
   }
 
-  s.prepend(svelteModule.content)
+  if (optionsModule) s.prepend(svelteModule.content)
 
   return {
     code: s.toString(),

--- a/packages/markdown/src/compile/types/compile.ts
+++ b/packages/markdown/src/compile/types/compile.ts
@@ -3,4 +3,16 @@ import type { MarkdownConfig } from '@/config/types'
 export interface CompileOptions {
   filename?: string
   config?: MarkdownConfig
+  /**
+   * @experimental This option is experimental and may change at any time, so use it with caution.
+   *
+   * @default true
+   */
+  htmlTag?: boolean
+  /**
+   * @experimental This option is experimental and may change at any time, so use it with caution.
+   *
+   * @default true
+   */
+  module?: boolean
 }

--- a/packages/markdown/src/plugins/rehype/code.ts
+++ b/packages/markdown/src/plugins/rehype/code.ts
@@ -4,7 +4,13 @@ import { escapeSvelte } from '@/utils'
 import type { Root } from 'hast'
 import type { Plugin } from '@/plugins/types'
 
-export const rehypeRenderCode: Plugin<[], Root> = () => {
+interface Options {
+  htmlTag?: boolean
+}
+
+export const rehypeRenderCode: Plugin<[Options?], Root> = ({
+  htmlTag,
+}: Options = {}) => {
   return (tree) => {
     visit(tree, 'element', (node) => {
       if (!['pre', 'code'].includes(node.tagName)) return
@@ -17,9 +23,11 @@ export const rehypeRenderCode: Plugin<[], Root> = () => {
         characterReferences: { useNamedReferences: true },
       })
 
+      const parsed = escapeSvelte(value)
+
       Object.assign(code, {
         type: 'raw',
-        value: `{@html \`${escapeSvelte(value)}\`}`,
+        value: htmlTag ? `{@html \`${parsed}\`}` : parsed,
       })
     })
   }


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types

## Request Description

Adds new `experimental` options to the `compile` function.

### API

```ts
export interface CompileOptions {
  /**
   * @experimental This option is experimental and may change at any time, so use it with caution.
   *
   * @default true
   */
  htmlTag?: boolean
  /**
   * @experimental This option is experimental and may change at any time, so use it with caution.
   *
   * @default true
   */
  module?: boolean
}

const compiled = await compile(content, { htmlTag: false, module: false })
```

### Example

```ts
// page.server.ts

import { compile } from '@sveltek/markdown'
import type { PageServerLoad } from './$types'

export const load: PageServerLoad = async () => {
  const content = `
  # @sveltek/markdown

  - this \`works\` as expected
  `
  const compiled = await compile(content, { htmlTag: false, module: false })

  // console.log(compiled.code)

  return { page: { content: compiled.code } }
}
```

### Page

```html
<!-- +page.svelte -->

<script lang="ts">
  let { data } = $props()
</script>

{@html data.page.content}
```

**Output**

```txt
<h1>@sveltek/markdown</h1>
<ul>
<li>this <code>works</code> as expected</li>
</ul>
```

Related #18
