### PR TITLE
feat(unplugins): add new remark reading stats plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,35 +376,15 @@ description: Read the latest news.
 
 ### Remark Reading Stats
 
-```ts
-import { visit, CONTINUE } from 'unist-util-visit'
-import readingTime from 'reading-time'
-import type { Frontmatter } from '@sveltek/markdown'
-import type { Plugin, Mdast } from '@sveltek/unplugins'
-
-/**
- * Estimates how long an article will take to read.
- */
-export const remarkReadingStats: Plugin<[], Mdast.Root> = () => {
-  return (tree, file) => {
-    const frontmatter = file.data.frontmatter as Frontmatter
-
-    let text = ''
-
-    visit(tree, ['text', 'code'], (node) => {
-      if (node.type !== 'text' && node.type !== 'code') return CONTINUE
-
-      text += node.value
-
-      frontmatter.readingStats = readingTime(text)
-    })
-  }
-}
-```
-
-Config:
+> Install the required dependencies before use.
+>
+> ```sh
+> pnpm add -D @sveltek/unplugins
+> ```
 
 ```js
+import { remarkReadingStats } from '@sveltek/unplugins'
+
 svelteMarkdown({
   plugins: {
     remark: [remarkReadingStats],
@@ -419,13 +399,11 @@ Usage in markdown page:
 title: Page title
 ---
 
-Reading stats: {JSON.stringify(readingStats)}
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
-# returns an object: { text: '1 min read', minutes: 1, time: 60000, words: 200 }
+Reading Stats {JSON.stringify(readingStats)}
 
-Reading time: {readingStats.text}
-
-# returns an string: '1 min read'
+Reading Time: {readingStats.text}
 ```
 
 ## API

--- a/packages/unplugins/src/remark/index.ts
+++ b/packages/unplugins/src/remark/index.ts
@@ -1,1 +1,2 @@
 export * from './toc'
+export * from './reading-stats'

--- a/packages/unplugins/src/remark/reading-stats/index.ts
+++ b/packages/unplugins/src/remark/reading-stats/index.ts
@@ -1,0 +1,53 @@
+import { visit } from 'unist-util-visit'
+import { readingStats } from './stats'
+import type { Root } from 'mdast'
+import type { Plugin } from '@/types'
+import type { ReadingStatsOptions, ReadingStats } from './types'
+
+/**
+ * A custom `Remark` plugin that creates `Reading Stats`.
+ *
+ * Stores reading details to `frontmatter` for easy access.
+ *
+ * @example
+ *
+ * ```ts
+ * import { svelteMarkdown } from '@sveltek/markdown'
+ * import { remarkReadingStats } from '@sveltek/unplugins'
+ *
+ * svelteMarkdown({
+ *   plugins: {
+ *     remark: [remarkReadingStats]
+ *   }
+ * })
+ * ```
+ *
+ * Or with options:
+ *
+ * ```js
+ * svelteMarkdown({
+ *   plugins: {
+ *     remark: [[remarkReadingStats, { wordsPerMinute: 300 }]]
+ *   }
+ * })
+ * ```
+ */
+export const remarkReadingStats: Plugin<[ReadingStatsOptions?], Root> = (
+  options: ReadingStatsOptions = {},
+) => {
+  const { wordsPerMinute } = options
+
+  return (tree, vfile) => {
+    const frontmatter = vfile.data.frontmatter as {
+      readingStats: ReadingStats
+    }
+
+    let text = ''
+
+    visit(tree, 'text', (node) => {
+      text += node.value
+    })
+
+    frontmatter.readingStats = readingStats(text, { wordsPerMinute })
+  }
+}

--- a/packages/unplugins/src/remark/reading-stats/stats.ts
+++ b/packages/unplugins/src/remark/reading-stats/stats.ts
@@ -1,0 +1,18 @@
+import type { ReadingStats } from './types'
+
+interface Options {
+  wordsPerMinute?: number
+}
+
+const countWords = (text: string): number => (text.match(/\S+/g) || []).length
+
+export const readingStats = (
+  text: string,
+  { wordsPerMinute = 200 }: Options = {},
+): ReadingStats => {
+  const words = countWords(text)
+  const min = words / wordsPerMinute
+  const minutes = min < 1 ? 1 : Math.round(min * 10) / 10
+
+  return { minutes, words, text: `${minutes} min read` }
+}

--- a/packages/unplugins/src/remark/reading-stats/types.ts
+++ b/packages/unplugins/src/remark/reading-stats/types.ts
@@ -1,0 +1,14 @@
+export interface ReadingStats {
+  minutes: number
+  words: number
+  text: string
+}
+
+export interface ReadingStatsOptions {
+  /**
+   * Specifies how many words per minute an average reader can read.
+   *
+   * @default 200
+   */
+  wordsPerMinute?: number
+}

--- a/packages/unplugins/src/remark/types.ts
+++ b/packages/unplugins/src/remark/types.ts
@@ -1,3 +1,4 @@
 export * from './toc/types'
+export * from './reading-stats/types'
 
 export * from './'

--- a/playgrounds/sveltekit/markdown.config.js
+++ b/playgrounds/sveltekit/markdown.config.js
@@ -1,5 +1,9 @@
 import { defineConfig } from '../../packages/markdown/dist/index.mjs'
-import { remarkToc, rehypeShiki } from '../../packages/unplugins/dist/index.mjs'
+import {
+  remarkToc,
+  remarkReadingStats,
+  rehypeShiki,
+} from '../../packages/unplugins/dist/index.mjs'
 
 export const markdownConfig = defineConfig({
   frontmatter: {
@@ -25,6 +29,11 @@ export const markdownConfig = defineConfig({
     blog: {
       plugins: {
         remark: [remarkToc],
+      },
+    },
+    support: {
+      plugins: {
+        remark: [remarkReadingStats],
       },
     },
   },

--- a/playgrounds/sveltekit/src/routes/support/+page.md
+++ b/playgrounds/sveltekit/src/routes/support/+page.md
@@ -1,7 +1,18 @@
 ---
 title: Support page
 description: Our friendly team is here to help.
+entry: support
 layout: false
 ---
 
-content...
+Reading Stats {JSON.stringify(readingStats)}
+
+Reading Time: {readingStats.text}
+
+## Support
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Contact
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types
- [x] Documentation


## Request Description

Adds new `remarkReadingStats` plugin.

### remarkReadingStats

A custom `Remark` plugin that creates `Reading Stats`.

Stores reading details to `frontmatter` for easy access.

```ts
import { svelteMarkdown } from '@sveltek/markdown'
import { remarkReadingStats } from '@sveltek/unplugins'

svelteMarkdown({
  plugins: {
    remark: [remarkReadingStats]
  }
})
```

Or with options:

```js
svelteMarkdown({
  plugins: {
    remark: [[remarkReadingStats, { wordsPerMinute: 300 }]]
  }
})
```


#### Usage in markdown page:

```markdown
---
title: Page title
---

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

Reading Stats {JSON.stringify(readingStats)}

Reading Time: {readingStats.text}
```
