### PR TITLE
feat(unplugins): add new code-to-html options to rehype-shiki plugin

### DIFF
--- a/packages/unplugins/src/rehype/shiki/index.ts
+++ b/packages/unplugins/src/rehype/shiki/index.ts
@@ -1,3 +1,4 @@
+import { isFunction } from './utils'
 import type { HighlightOptions } from '@sveltek/markdown'
 import type { BuiltinTheme } from 'shiki'
 import type { Root } from 'hast'
@@ -38,7 +39,7 @@ export const rehypeShiki: Plugin<[ShikiOptions?], Root> = function (
     themes,
     langs,
     highlighter,
-    codeToHtml: codeHtml,
+    codeToHtml: codeHtmlOptions,
     root = (node) => {
       node.tagName = 'div'
     },
@@ -61,7 +62,12 @@ export const rehypeShiki: Plugin<[ShikiOptions?], Root> = function (
 
     const highlightOptions: HighlightOptions = {
       highlighter: async ({ code, lang, meta }) => {
-        options.parseMeta?.(meta)
+        const parsedMeta = options.parseMeta?.(meta)
+        if (parsedMeta) meta = parsedMeta
+
+        const codeHtml = isFunction(codeHtmlOptions)
+          ? codeHtmlOptions({ code, lang, meta })
+          : codeHtmlOptions
 
         if (code) {
           return codeToHtml(code, {

--- a/packages/unplugins/src/rehype/shiki/types.ts
+++ b/packages/unplugins/src/rehype/shiki/types.ts
@@ -4,7 +4,7 @@ import {
   type CodeOptionsSingleTheme,
   type CodeOptionsMultipleThemes,
 } from 'shiki'
-import type { HighlightOptions } from '@sveltek/markdown'
+import type { HighlightOptions, HighlighterData } from '@sveltek/markdown'
 
 type HighlighterOptions = Parameters<typeof createHighlighter>[0]
 
@@ -67,15 +67,19 @@ export interface ShikiOptions {
    *
    * @default undefined
    */
-  codeToHtml?: CodeToHastOptions &
-    CodeOptionsSingleTheme &
-    CodeOptionsMultipleThemes
+  codeToHtml?:
+    | (CodeToHastOptions & CodeOptionsSingleTheme & CodeOptionsMultipleThemes)
+    | ((
+        data: HighlighterData,
+      ) => CodeToHastOptions &
+        CodeOptionsSingleTheme &
+        CodeOptionsMultipleThemes)
   /**
    * Parses `meta` string from the code block.
    *
    * @default undefined
    */
-  parseMeta?: (meta: string | undefined) => void
+  parseMeta?: (meta: string | undefined) => void | string
   /**
    * Specifies custom options for the `root` node (usually the `<pre>` tag).
    *

--- a/packages/unplugins/src/rehype/shiki/utils.ts
+++ b/packages/unplugins/src/rehype/shiki/utils.ts
@@ -1,0 +1,2 @@
+export const isFunction = (v: any): v is (...args: any[]) => unknown =>
+  v instanceof Function

--- a/playgrounds/sveltekit/markdown.config.js
+++ b/playgrounds/sveltekit/markdown.config.js
@@ -5,6 +5,26 @@ import {
   rehypeShiki,
 } from '../../packages/unplugins/dist/index.mjs'
 
+/** @type {import('../../packages/unplugins/dist/index.mjs').ShikiOptions} */
+export const shikiConfig = {
+  langs: ['html', 'javascript', 'typescript', 'svelte', 'shellscript'],
+  codeToHtml: ({ lang, meta }) => ({
+    tabindex: false,
+    transformers: [
+      {
+        name: 'transformer-metadata',
+        pre(node) {
+          node.properties['data-theme'] = 'hypernym-dark'
+          node.properties['data-lang'] = `${lang}`
+
+          const isNumbers = meta?.includes('line-numbers') || false
+          node.properties['data-line-numbers'] = `${isNumbers}`
+        },
+      },
+    ],
+  }),
+}
+
 export const markdownConfig = defineConfig({
   frontmatter: {
     defaults: {
@@ -23,7 +43,7 @@ export const markdownConfig = defineConfig({
   entries: {
     about: {
       plugins: {
-        rehype: [rehypeShiki],
+        rehype: [[rehypeShiki, shikiConfig]],
       },
     },
     blog: {

--- a/playgrounds/sveltekit/src/routes/about/+page.md
+++ b/playgrounds/sveltekit/src/routes/about/+page.md
@@ -28,7 +28,7 @@ specialElements: true
 
 <Button />
 
-```ts
+```ts line-numbers
 // Code example
 console.log('@sveltek/markdown')
 ```

--- a/playgrounds/sveltekit/src/styles/app.css
+++ b/playgrounds/sveltekit/src/styles/app.css
@@ -11,3 +11,19 @@ a:visited {
   color: white;
   text-decoration: none;
 }
+
+pre[data-line-numbers='true'] {
+  counter-reset: step;
+  counter-increment: step 0;
+
+  .line::before {
+    content: counter(step);
+    counter-increment: step;
+    opacity: 0.5;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: 1rem;
+    margin-right: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types

## Request Description

Extends the `codeToHtml` options in `rehype-shiki` plugin with new functionality.

Options can be written as a function, allowing access to `HighlighterData` parameters for advanced usage.

### Example

#### Simple

```ts
// markdown.config.mjs

import { defineConfig } from '@sveltek/markdown'
import { rehypeShiki } from '@sveltek/unplugins'

/** @type {import('@sveltek/unplugins').ShikiOptions} */
export const shikiConfig = {
  langs: ['html', 'javascript', 'typescript', 'svelte', 'shellscript'],
  codeToHtml: {
    tabindex: false,
  },
}

export const markdownConfig = defineConfig({
  plugins: {
    rehype: [[rehypeShiki, shikiConfig]],
  },
})
```

#### Advanced

```ts
// markdown.config.mjs

import { defineConfig } from '@sveltek/markdown'
import { rehypeShiki } from '@sveltek/unplugins'

/** @type {import('@sveltek/unplugins').ShikiOptions} */
export const shikiConfig = {
  langs: ['html', 'javascript', 'typescript', 'svelte', 'shellscript'],

  // optional metadate parsing
  parseMeta: (meta) => {
    const parsedMeta = customLogic(meta) // your custom logic for parsing, need to return final string
    return parsedMeta // returns new meta
  },

  // advanced usage
  codeToHtml: ({ lang, meta }) => ({
    tabindex: false,
    transformers: [
      {
        name: 'transformer-metadata',
        pre(node) {
          node.properties['data-theme'] = 'hypernym-dark'
          node.properties['data-lang'] = `${lang}`

          const isNumbers = meta?.includes('line-numbers') || false
          node.properties['data-line-numbers'] = `${isNumbers}`
        },
      },
    ],
  }),
}

export const markdownConfig = defineConfig({
  plugins: {
    rehype: [[rehypeShiki, shikiConfig]],
  },
})
```
