### PR TITLE
break: update layouts and entries options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ export const markdownConfig = defineConfig({
       // other global data...
     },
   },
-  layouts: {
-    default: {
+  layouts: [
+    {
+      name: 'default',
       path: 'lib/content/layouts/default/layout.svelte',
     },
-    blog: {
+    {
+      name: 'blog',
       path: 'lib/content/layouts/blog/layout.svelte',
       plugins: {
         remark: [],
@@ -103,7 +105,7 @@ export const markdownConfig = defineConfig({
       },
     },
     // other layouts...
-  },
+  ],
 })
 ```
 
@@ -577,10 +579,10 @@ Content...
 
 ### layouts
 
-- Type: `Record<string, Layout>`
+- Type: `Layout[]`
 - Default: `undefined`
 
-Specifies a custom layout records.
+Specifies a custom layout array.
 
 Layout component serves as a wrapper for the markdown files, which means the page content is displayed via the component's children prop.
 
@@ -588,18 +590,20 @@ Layout component serves as a wrapper for the markdown files, which means the pag
 
 ```ts
 svelteMarkdown({
-  layouts: {
-    default: {
+  layouts: [
+    {
+      name: 'default',
       path: 'lib/content/layouts/default/layout.svelte', // Specifies the path to the layout file (required).
       plugins: {
         remark: [], // Specifies custom `remark` plugins at the layout-level (optional).
         rehype: [], // Specifies custom `rehype` plugins at the layout-level (optional).
       },
     },
-    blog: {
+    {
+      name: 'blog',
       path: 'lib/content/layouts/blog/layout.svelte',
     },
-  },
+  ],
 })
 ```
 
@@ -645,10 +649,10 @@ svelteMarkdown({
 
 ### entries
 
-- Type: `Record<string, Entry>`
+- Type: `Entry[]`
 - Default: `undefined`
 
-Specifies a custom entry records.
+Specifies a custom entry array.
 
 Entry serves as a special configuration for markdown files, which means it is similar to layout but without the need to create a custom component file.
 
@@ -658,14 +662,15 @@ Allows unique and straightforward customization for an individual markdown file.
 
 ```ts
 svelteMarkdown({
-  entries: {
-    blog: {
+  entries: [
+    {
+      name: 'blog',
       plugins: {
         remark: [], // Specifies custom `remark` plugins at the entry-level (optional).
         rehype: [], // Specifies custom `rehype` plugins at the entry-level (optional).
       },
     },
-  },
+  ],
 })
 ```
 
@@ -711,7 +716,7 @@ svelteMarkdown({
 
 ### components
 
-- Type: `object[]`
+- Type: `Component[]`
 - Default: `undefined`
 
 Defines global components that can be used in all markdown files without manual setup.

--- a/packages/markdown/src/compile/entries.ts
+++ b/packages/markdown/src/compile/entries.ts
@@ -11,12 +11,11 @@ export function getEntryData(
   if (!config.entries || !entry) return
 
   const entryName = isObject(entry) ? entry.name : entry
+  const entryConfig = config.entries.find(({ name }) => name === entryName)
 
-  const entryConfig = config.entries[entryName]
   if (!entryConfig) {
-    throw new TypeError(
-      `Invalid entry name. Valid names are: ${Object.keys(config.entries).join(', ')}.`,
-    )
+    const names = config.entries.map((entry) => `"${entry.name}"`).join(', ')
+    throw new TypeError(`Invalid entry name. Valid names are: ${names}.`)
   }
 
   return entryConfig

--- a/packages/markdown/src/compile/layouts.ts
+++ b/packages/markdown/src/compile/layouts.ts
@@ -5,22 +5,18 @@ import type { FileData, Layout } from './types'
 export function getLayoutData(
   data: FileData,
   config: MarkdownConfig = {},
-): (Layout & { name: string | false }) | undefined {
+): Layout | undefined {
   const { layout } = data.frontmatter!
 
   if (!config.layouts || !layout) return
 
   const layoutName = isObject(layout) ? layout.name : layout
+  const layoutConfig = config.layouts.find(({ name }) => name === layoutName)
 
-  const layoutConfig = config.layouts[layoutName]
   if (!layoutConfig) {
-    throw new TypeError(
-      `Invalid layout name. Valid names are: ${Object.keys(config.layouts).join(', ')}.`,
-    )
+    const names = config.layouts.map((layout) => `"${layout.name}"`).join(', ')
+    throw new TypeError(`Invalid layout name. Valid names are: ${names}.`)
   }
 
-  return {
-    name: layoutName,
-    ...layoutConfig,
-  }
+  return layoutConfig
 }

--- a/packages/markdown/src/compile/types/components.ts
+++ b/packages/markdown/src/compile/types/components.ts
@@ -1,12 +1,12 @@
 export interface GlobalComponent {
   /**
-   * Specifies the component path.
-   */
-  path: string
-  /**
    * Specifies the component name.
    */
   name: string
+  /**
+   * Specifies the component path.
+   */
+  path: string
   /**
    * Specifies the component import form.
    *

--- a/packages/markdown/src/compile/types/entries.ts
+++ b/packages/markdown/src/compile/types/entries.ts
@@ -2,6 +2,10 @@ import type { PluginList } from '@/plugins/types'
 
 export interface Entry {
   /**
+   * Specifies the entry name.
+   */
+  name: string
+  /**
    * Specifies the **entry-specific** plugins that will only be applied to this particular markdown file.
    *
    * Also, these plugins will run after **top-level** and **layout-level** plugins.
@@ -28,4 +32,4 @@ export interface Entry {
   }
 }
 
-export type Entries = Record<string, Entry>
+export type Entries = Entry[]

--- a/packages/markdown/src/compile/types/layouts.ts
+++ b/packages/markdown/src/compile/types/layouts.ts
@@ -2,6 +2,10 @@ import type { PluginList } from '@/plugins/types'
 
 export interface Layout {
   /**
+   * Specifies the layout name.
+   */
+  name: string
+  /**
    * Specifies the path to the layout file.
    */
   path: string
@@ -32,4 +36,4 @@ export interface Layout {
   }
 }
 
-export type Layouts = Record<string, Layout>
+export type Layouts = Layout[]

--- a/packages/markdown/src/config/index.ts
+++ b/packages/markdown/src/config/index.ts
@@ -15,11 +15,12 @@ import type { MarkdownConfig } from './types'
  *       author: 'Sveltek',
  *     },
  *   },
- *   layouts: {
- *     default: {
+ *   layouts: [
+ *     {
+ *       name: 'default',
  *       path: 'lib/content/layouts/default/layout.svelte',
  *     },
- *   },
+ *   ],
  * })
  * ```
  */

--- a/packages/markdown/src/config/types.ts
+++ b/packages/markdown/src/config/types.ts
@@ -70,7 +70,7 @@ export interface MarkdownConfig {
     rehype?: PluginList
   }
   /**
-   * Specifies a custom layout records.
+   * Specifies a custom layout array.
    *
    * Layout component serves as a wrapper for the markdown files, which means the page content is displayed via the component's children prop.
    *
@@ -80,7 +80,7 @@ export interface MarkdownConfig {
    */
   layouts?: Layouts
   /**
-   * Specifies a custom entry records.
+   * Specifies a custom entry array.
    *
    * Entry serves as a special configuration for markdown files, which means it is similar to layout but without the need to create a custom component file.
    *


### PR DESCRIPTION

## Type of Change

<!-- Check the boxes with an 'x' that refers to your changes. -->

- [x] Breaking change
- [x] Refactoring Code
- [x] Documentation

## Request Description

Updates global `layouts` and `entries` options.

All global `layouts`, `entries` and `components` options are now aligned, predictable and easier to follow.

### layouts

- **Prev Type:** `Record<string, Record<string, unknown>>`
- **New Type:** `object[]`

```diff
svelteMarkdown({
-  layouts: {
-    default: {
-      path: '...',
-    },
-  },
+  layouts: [
+    {
+      name: 'default',
+      path: '...',
+    },
+  ]
})
```

### entries

- **Prev Type:** `Record<string, Record<string, unknown>>`
- **New Type:** `object[]`

```diff
svelteMarkdown({
-  entries: {
-    default: {
-      path: '...',
-    },
-  },
+  entries: [
+    {
+      name: 'default',
+      path: '...',
+    },
+  ]
})
```

### Important ⚠️

Everything else is the same, no need to change pages or components.

The configuration should now be more readable and clearer.

